### PR TITLE
Try to use srcObject and gracefully falls back to src if srcObject throws an error

### DIFF
--- a/vendor/assets/javascripts/jpeg_camera/jpeg_camera.js
+++ b/vendor/assets/javascripts/jpeg_camera/jpeg_camera.js
@@ -321,10 +321,23 @@
         success = function(stream) {
           that._remove_message();
           if (window.URL) {
-            that.video.src = URL.createObjectURL(stream);
-          } else {
-            that.video.src = stream;
-          }
+		    /**
+		     * Try to use srcObject and gracefully
+		     * falls back to src if srcObject throws an error.
+		     */
+		    try {
+		      that.video.srcObject = stream;
+		    } catch (error) {
+		      /**
+		       * [Deprecation] URL.createObjectURL with media streams is deprecated and will be removed in M68,
+		       *  around July 2018. Please use HTMLMediaElement.srcObject instead.
+		       *  See https://www.chromestatus.com/features/5618491470118912 for more details.
+		       */
+		      that.video.src = URL.createObjectURL(stream);
+			}
+		  } else {
+		    that.video.src = stream;
+		  }
           that._block_element_access();
           return that._wait_for_video_ready();
         };

--- a/vendor/assets/javascripts/jpeg_camera/jpeg_camera.js
+++ b/vendor/assets/javascripts/jpeg_camera/jpeg_camera.js
@@ -321,23 +321,23 @@
         success = function(stream) {
           that._remove_message();
           if (window.URL) {
-		    /**
-		     * Try to use srcObject and gracefully
-		     * falls back to src if srcObject throws an error.
-		     */
-		    try {
-		      that.video.srcObject = stream;
-		    } catch (error) {
-		      /**
-		       * [Deprecation] URL.createObjectURL with media streams is deprecated and will be removed in M68,
-		       *  around July 2018. Please use HTMLMediaElement.srcObject instead.
-		       *  See https://www.chromestatus.com/features/5618491470118912 for more details.
-		       */
-		      that.video.src = URL.createObjectURL(stream);
-			}
-		  } else {
-		    that.video.src = stream;
-		  }
+           /**
+            * Try to use srcObject and gracefully
+            * falls back to src if srcObject throws an error.
+            */
+            try {
+              that.video.srcObject = stream;
+            } catch (error) {
+             /**
+              * [Deprecation] URL.createObjectURL with media streams is deprecated and will be removed in M68,
+              *  around July 2018. Please use HTMLMediaElement.srcObject instead.
+              *  See https://www.chromestatus.com/features/5618491470118912 for more details.
+              */
+              that.video.src = URL.createObjectURL(stream);
+            }
+          } else {
+            that.video.src = stream;
+          }
           that._block_element_access();
           return that._wait_for_video_ready();
         };


### PR DESCRIPTION
Since URL.createObjectURL is going to become deprecated: 

"[Deprecation] `URL.createObjectURL` with media streams is deprecated and will be removed in M68, around July 2018. Please use `HTMLMediaElement.srcObject` instead. See _https://www.chromestatus.com/features/5618491470118912_ for more details."

I changed the stream to be assigned in the `srcObject` property.

I hope you don't mind!

Regards.
    