### PR TITLE
Update jpeg_camera_html5.coffee

### DIFF
--- a/src/jpeg_camera_html5.coffee
+++ b/src/jpeg_camera_html5.coffee
@@ -87,10 +87,13 @@ if navigator.getUserMedia
         (stream) ->
           that._remove_message()
 
-          if window.URL
-            that.video.src = URL.createObjectURL stream
+          #patch for FF 62
+          if typeof that.video.srcObject is "object"
+              that.video.srcObject = stream
+          else if window.URL
+              that.video.src = URL.createObjectURL stream
           else
-            that.video.src = stream
+              that.video.src = stream
 
           that._block_element_access()
 


### PR DESCRIPTION
Patch for invalidargument URL.createObjectURL in FF 62.0.2